### PR TITLE
Add pytest suite for dml utilities

### DIFF
--- a/tests/deepecon/dml/data_utils.py
+++ b/tests/deepecon/dml/data_utils.py
@@ -1,0 +1,12 @@
+import torch
+
+
+def generate_toy_data(n=200, p=5, seed=0):
+    """Generate simple synthetic data for testing."""
+    torch.manual_seed(seed)
+    X = torch.randn(n, p)
+    beta = torch.arange(1.0, p + 1.0)
+    logits = (X @ beta * 0.1)
+    T = torch.bernoulli(torch.sigmoid(logits))
+    Y = X @ beta + 0.5 * T + torch.randn(n)
+    return X, T, Y

--- a/tests/deepecon/dml/test_data_utils.py
+++ b/tests/deepecon/dml/test_data_utils.py
@@ -1,0 +1,12 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from .data_utils import generate_toy_data
+
+
+def test_generate_toy_data_shapes():
+    X, T, Y = generate_toy_data(n=50, p=4, seed=1)
+    assert X.shape == (50, 4)
+    assert T.shape == (50,)
+    assert Y.shape == (50,)

--- a/tests/deepecon/dml/test_default_ml.py
+++ b/tests/deepecon/dml/test_default_ml.py
@@ -1,0 +1,41 @@
+import pytest
+torch = pytest.importorskip("torch")
+linear = pytest.importorskip("sklearn.linear_model")
+ensemble = pytest.importorskip("sklearn.ensemble")
+from deepecon.dml import _default_ml
+
+
+def test_default_model_y_output_shape():
+    model = _default_ml.default_model_y(3)
+    x = torch.randn(5, 3)
+    y = model(x)
+    assert y.shape == (5, 1)
+
+
+def test_default_model_t_discrete_and_continuous():
+    model_d = _default_ml.default_model_t(4, discrete=True)
+    model_c = _default_ml.default_model_t(4, discrete=False)
+    x = torch.randn(2, 4)
+    assert model_d(x).shape == (2, 1)
+    assert model_c(x).shape == (2, 1)
+
+
+def test_default_sklearn_lasso():
+    factory = _default_ml.default_sklearn_lasso(alpha=0.5)
+    model = factory()
+    assert isinstance(model, linear.LassoCV)
+    assert 0.5 in model.alphas
+
+
+def test_default_sklearn_ridge():
+    factory = _default_ml.default_sklearn_ridge(alphas=[0.1, 1.0])
+    model = factory()
+    assert isinstance(model, linear.RidgeCV)
+    assert model.alphas.tolist() == [0.1, 1.0]
+
+
+def test_default_sklearn_forest():
+    f_reg = _default_ml.default_sklearn_forest(discrete=False)
+    f_clf = _default_ml.default_sklearn_forest(discrete=True)
+    assert isinstance(f_reg(), ensemble.RandomForestRegressor)
+    assert isinstance(f_clf(), ensemble.RandomForestClassifier)

--- a/tests/deepecon/dml/test_dml_base.py
+++ b/tests/deepecon/dml/test_dml_base.py
@@ -1,0 +1,13 @@
+import pytest
+torch = pytest.importorskip("torch")
+
+from deepecon.dml.dml import DML
+
+
+def simple_builder(dim):
+    return torch.nn.Linear(dim, 1)
+
+
+def test_dml_is_abstract():
+    with pytest.raises(TypeError):
+        DML(simple_builder, simple_builder)

--- a/tests/deepecon/dml/test_ortho_learner.py
+++ b/tests/deepecon/dml/test_ortho_learner.py
@@ -1,0 +1,43 @@
+import pytest
+torch = pytest.importorskip("torch")
+
+from deepecon.dml._ortho_learner import OrthogonalLearner
+
+
+class DummyOrthogonalLearner(OrthogonalLearner):
+    def fit(self, X, T, Y, W=None):
+        self._theta = 1.0
+        self._resid_y = torch.zeros(len(Y))
+        self._resid_t = torch.zeros(len(T))
+
+    def effect(self, X_test: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+
+def simple_builder(dim):
+    return torch.nn.Linear(dim, 1)
+
+
+def test_orthogonal_learner_methods():
+    learner = DummyOrthogonalLearner(simple_builder, simple_builder)
+
+    with pytest.raises(RuntimeError):
+        learner.ate()
+
+    with pytest.raises(RuntimeError):
+        learner.get_residuals()
+
+    learner.fit(torch.randn(5, 3), torch.ones(5), torch.ones(5))
+    assert learner.ate() == 1.0
+    resid_y, resid_t = learner.get_residuals()
+    assert resid_y.shape[0] == 5
+    assert resid_t.shape[0] == 5
+
+    with pytest.raises(NotImplementedError):
+        learner.effect(torch.randn(1, 3))
+
+
+def test_base_abstract_fit():
+    base = OrthogonalLearner(simple_builder, simple_builder)
+    with pytest.raises(NotImplementedError):
+        base.fit(torch.randn(2, 2), torch.ones(2), torch.ones(2))

--- a/tests/deepecon/dml/test_utils.py
+++ b/tests/deepecon/dml/test_utils.py
@@ -1,0 +1,65 @@
+import pytest
+torch = pytest.importorskip("torch")
+import numpy as np
+import random
+
+from deepecon.dml import _utils
+
+
+def test_set_random_seed_determinism():
+    _utils.set_random_seed(123)
+    val1 = (random.random(), np.random.rand(), torch.randn(1).item())
+    _utils.set_random_seed(123)
+    val2 = (random.random(), np.random.rand(), torch.randn(1).item())
+    assert val1 == val2
+
+
+def test_set_random_seed_negative():
+    with pytest.raises(ValueError):
+        _utils.set_random_seed(-1)
+
+
+def test_get_device():
+    device = _utils.get_device()
+    assert device in {"cuda", "cpu"}
+
+
+def test_split_indices_basic():
+    splits = _utils.split_indices(10, 5, shuffle=False)
+    assert len(splits) == 5
+    all_val = sum((val for _, val in splits), [])
+    assert sorted(all_val) == list(range(10))
+    for train, val in splits:
+        assert set(train).isdisjoint(val)
+
+
+def test_split_indices_invalid():
+    with pytest.raises(ValueError):
+        _utils.split_indices(5, 1)
+    with pytest.raises(ValueError):
+        _utils.split_indices(5, 6)
+
+
+def test_compute_theta_from_residuals():
+    t = torch.tensor([1.0, 1.0, 1.0])
+    y = torch.tensor([2.0, 2.0, 2.0])
+    theta = _utils.compute_theta_from_residuals(t, y)
+    assert theta == pytest.approx(2.0)
+
+    with pytest.raises(ValueError):
+        _utils.compute_theta_from_residuals(torch.tensor([0.0, 0.0]), torch.tensor([1.0, 1.0]))
+
+    with pytest.raises(ValueError):
+        _utils.compute_theta_from_residuals(torch.tensor([1.0, 2.0]), torch.tensor([1.0]))
+
+
+def test_bootstrap_ate_ci():
+    t = torch.ones(20)
+    y = torch.ones(20) * 2
+    lower, upper = _utils.bootstrap_ate_ci(t, y, n_bootstrap=100, seed=0)
+    assert lower < 2.0 < upper
+
+    with pytest.raises(ValueError):
+        _utils.bootstrap_ate_ci(t, y, n_bootstrap=0)
+    with pytest.raises(ValueError):
+        _utils.bootstrap_ate_ci(t, y, alpha=1.0)


### PR DESCRIPTION
## Summary
- add unit test directory for deepecon.dml
- include helper to generate toy data
- cover utilities, default models and base classes with pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684081e77dfc8320b2cfeb8a39f8522d